### PR TITLE
Update regex in get-map-list.sh

### DIFF
--- a/get-map-list.sh
+++ b/get-map-list.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 #./get-map-list.py
-curl -s https://tempus.xyz/api/maps/list | grep -o "\"name\": \"[a-zA-Z_]*\"" | cut -d' ' -f 2 | cut -c 2- | sed 's/.$//' > maps.csv
+curl -s https://tempus.xyz/api/maps/list | grep -o "\"name\": \"[a-zA-Z0-9_]*\"" | cut -d' ' -f 2 | cut -c 2- | sed 's/.$//' > maps.csv
 
 echo maps.csv file created


### PR DESCRIPTION
Right now, this script only grabs maps that have no numbers anywhere in their name which omits over half of the entire Tempus map catalog.